### PR TITLE
Fixes to URL Breaks & CI Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "ci"
+      - "dependabot"
+    open-pull-requests-limit: 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: always()
-        with: 
+        with:
           name: github-pages
           path: |
             build/html/*
@@ -69,7 +69,7 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-    
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -48,7 +48,7 @@ jobs:
           sphinx-build -M latexpdf ./source ./build --keep-going
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: github-pages
@@ -56,7 +56,7 @@ jobs:
             build/html/*
 
       - name: Upload PDF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: latex-pdf
@@ -65,7 +65,7 @@ jobs:
 
       - name: Generate a token for the UASAL builder app
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/source/conf.py
+++ b/source/conf.py
@@ -97,7 +97,7 @@ linkcheck_ignore = [
     # Zenodo returns 403 from CI runners
     'https://zenodo.org/records/*',
     # Link works but marks as broken for how this is resolving (either certificate or how its resolved)
-    'https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2934&context=smallsat',
+    'https://digitalcommons.usu.edu/*',
 ]
 
 # # Sites where the anchoring doesn't work correctly (often a redirect issue)

--- a/source/conf.py
+++ b/source/conf.py
@@ -96,6 +96,8 @@ linkcheck_ignore = [
     'https://doi.org/10.1117/12.2677714',
     # Zenodo returns 403 from CI runners
     'https://zenodo.org/records/*',
+    # Link works but marks as broken for how this is resolving (either certificate or how its resolved)
+    'https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=2934&context=smallsat',
 ]
 
 # # Sites where the anchoring doesn't work correctly (often a redirect issue)

--- a/source/hardware_testing.rst
+++ b/source/hardware_testing.rst
@@ -10,7 +10,7 @@ NASA resources
 
 - `NASA General Environmental Verification Standard (GEVS) <https://standards.nasa.gov/standard/gsfc/gsfc-std-7000>`__ ;
   also Milne, J. S., & Kaufman, D. S. (2003, January 1). `General Environmental Verification Specification. <https://ntrs.nasa.gov/citations/20030106019>`__
-- `NASA Sounding Rocket Handbook. (2015). Wallops Flight Facility Wallops Island, Virginia, USA. Sounding Rockets Program Office Suborbital & Special Orbital Projects Directorate <https://sites.wff.nasa.gov/code810/files/SRHB.pdf>`__
+- `NASA Sounding Rocket Handbook. (2015). Wallops Flight Facility Wallops Island, Virginia, USA. Sounding Rockets Program Office Suborbital & Special Orbital Projects Directorate <https://www.nasa.gov/wp-content/uploads/2023/09/sounding-rocket-program-handbook.pdf>`__
 - `Chapter 4 "CubeSat 101: Basic Concepts and Processes for First-Time CubeSat Developers". (2017). NASA. <https://www.nasa.gov/wp-content/uploads/2017/03/nasa_csli_cubesat_101_508.pdf>`__
 
 Assorted commercial resources (not vetted or endorsed)


### PR DESCRIPTION
## Description
Fixing link breaks or adding to ignore if resolving / redirecting as well as updating CI.

### Change Overview
- Fix link in `hardware_testing.rst` for NASA Sounding Rocket Handbook URL.
- Add https://digitalcommons.usu.edu/* to ignore URL list
- Add dependabot.yml
- Increment GitHub action versions for Node24 in deploy.sh
- Update app-id to client-id (changed repo variable to reflect as well)